### PR TITLE
Add support for the KAFKA_CREATE_TOPICS environment variable.

### DIFF
--- a/broker_helpers/configure_and_start_broker.sh
+++ b/broker_helpers/configure_and_start_broker.sh
@@ -7,4 +7,8 @@ sed -i 's|^#\(listeners=PLAINTEXT://\)\(:9092\)|\1'`hostname -i`'\2|' config/ser
 
 sed -i 's|^\(zookeeper.connect=\)\(localhost\)\(:2181\)|\1zookeeper\3|' config/server.properties
 
-./bin/kafka-server-start.sh config/server.properties
+# export environment variables used in create-topics.sh
+export KAFKA_ZOOKEEPER_CONNECT=zookeeper
+export KAFKA_PORT=9092
+
+/usr/bin/create-topics.sh & ./bin/kafka-server-start.sh config/server.properties


### PR DESCRIPTION
This will be useful for users who read the documentation for wurstmeister/kafka and believe they can still use the KAFKA_CREATE_TOPICS environment variable to have kafka-docker automatically create topics in Kafka during creation in this image as well. 

The documentation here and changes relative to the original image are fantastic, but the omission of the call to create-topics.sh led to some confusion for me at first. 
